### PR TITLE
Fix issues with resuming old runs

### DIFF
--- a/mc3/mcmc_driver.py
+++ b/mc3/mcmc_driver.py
@@ -113,10 +113,10 @@ def mcmc(data, uncert, func, params, indparams, pmin, pmax, pstep,
 
     if resume:
         oldrun = np.load(savefile)
-        zold = oldrun["Z"]
+        zold = oldrun["posterior"]
         zchain_old = oldrun["zchain"]
         # Size of posterior (prior to this MCMC sample):
-        pre_zsize = np.shape(zold)[0]
+        pre_zsize = M0 = np.shape(zold)[0]
     else:
         pre_zsize = M0 = hsize*nchains
 
@@ -174,7 +174,7 @@ def mcmc(data, uncert, func, params, indparams, pmin, pmax, pstep,
         log_post[0:pre_zsize] = oldrun["log_post"]
         # Redefine zsize:
         zsize.value = pre_zsize
-        numaccept.value = int(oldrun["numaccept"])
+        numaccept.value = int(oldrun["acceptance_rate"] / 100. * pre_zsize)
 
     # Set GR N-min as fraction if needed:
     if grnmin > 0 and grnmin < 1:
@@ -212,7 +212,7 @@ def mcmc(data, uncert, func, params, indparams, pmin, pmax, pstep,
             chainsize, bestp, best_log_post, i, ncpu))
 
     if resume:
-        bestp = oldrun['bestp']
+        bestp[:] = oldrun['bestp']
         best_log_post.value = oldrun['best_log_post']
         for c in range(nchains):
             chainsize[c] = np.sum(zchain_old==c)


### PR DESCRIPTION
Mostly fixes some naming differences between the .npz file and the code that sets up resumed runs. Also fixes a bug where the bestp array is overwritten with a non-shared array which doesn't correctly update during MCMC (only affects resumed runs).