### PR TITLE
Updated pyproject.toml adding oldest-supported-numpy as requirement

### DIFF
--- a/mc3/VERSION.py
+++ b/mc3/VERSION.py
@@ -4,6 +4,6 @@
 # mc3 Version:
 MC3_VER = 3  # Major version
 MC3_MIN = 0  # Minor version
-MC3_REV = 10  # Revision
+MC3_REV = 11  # Revision
 
 __version__ = f'{MC3_VER}.{MC3_MIN}.{MC3_REV}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,31 +2,7 @@
 requires = [
     'setuptools>=40.8.0',
     'wheel',
-
-    # Taken from scipy's pyproject, following
-    # https://github.com/scipy/oldest-supported-numpy/
-
-    # numpy 1.19 was the first minor release to provide aarch64 wheels, but
-    # wheels require fixes contained in numpy 1.19.2
-    "numpy==1.19.2; python_version=='3.6' and platform_machine=='aarch64'",
-    "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
-
-    # default numpy requirements
-    "numpy==1.16.5; python_version=='3.6' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
-    "numpy==1.16.5; python_version=='3.7' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
-    "numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
-    "numpy==1.19.3; python_version=='3.9' and platform_python_implementation != 'PyPy'",
-
-    # First PyPy versions for which there are numpy wheels
-    "numpy==1.19.0; python_version=='3.6' and platform_python_implementation=='PyPy'",
-    "numpy==1.20.0; python_version=='3.7' and platform_python_implementation=='PyPy'",
-
-    # For Python versions which aren't yet officially supported,
-    # we specify an unpinned NumPy which allows source distributions
-    # to be used and allows wheels to be used as soon as they
-    # become available.
-    "numpy; python_version>='3.10'",
-    "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
+    'oldest-supported-numpy',
     ]
 
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
to automate selecting the appropriate numpy version.
Bumped mc3 version to 3.0.11.