### PR TITLE
Make sure chains end gracefully and release all locks.

### DIFF
--- a/mc3/mcmc_driver.py
+++ b/mc3/mcmc_driver.py
@@ -297,6 +297,10 @@ def mcmc(data, uncert, func, params, indparams, pmin, pmax, pstep,
             if zsize.value == zlen:
                 break
 
+    # Make sure chains finish and release all locks
+    for chain in chains:
+        chain.join()
+        
     for chain in chains:  # Make sure to terminate the subprocesses
         chain.terminate()
 


### PR DESCRIPTION
This ensures that locks for things like numaccept and best_log_post are not enabled after the chains complete, which causes MC3 to hang indefinitely waiting for those locks to be freed.