### PR TITLE
Rychallener mpr fix

### DIFF
--- a/mc3/VERSION.py
+++ b/mc3/VERSION.py
@@ -4,6 +4,6 @@
 # mc3 Version:
 MC3_VER = 3  # Major version
 MC3_MIN = 0  # Minor version
-MC3_REV = 12  # Revision
+MC3_REV = 13  # Revision
 
 __version__ = f'{MC3_VER}.{MC3_MIN}.{MC3_REV}'

--- a/mc3/mcmc_driver.py
+++ b/mc3/mcmc_driver.py
@@ -297,6 +297,10 @@ def mcmc(data, uncert, func, params, indparams, pmin, pmax, pstep,
             if zsize.value == zlen:
                 break
 
+    # Make sure chains finish and release all locks
+    for chain in chains:
+        chain.join()
+        
     for chain in chains:  # Make sure to terminate the subprocesses
         chain.terminate()
 


### PR DESCRIPTION
Added some lock() and join() calls to have a safer multiprocessing calculations/processes termination.